### PR TITLE
Fix model caching and add subprocess fallback for VRAM savings For Linux

### DIFF
--- a/nodes/model_loaders.py
+++ b/nodes/model_loaders.py
@@ -144,6 +144,23 @@ class UniRigLoadSkeletonModel:
             # Update cache_to_gpu setting in case it changed
             cached_model["cache_to_gpu"] = cache_to_gpu
             print(f"[UniRigLoadSkeletonModel] Using cached model configuration")
+            
+            # If cache_to_gpu is enabled but model is not in GPU memory, load it now
+            if cache_to_gpu and cached_model.get("model_cache_key") is None:
+                model_cache = _get_model_cache()
+                if model_cache:
+                    print(f"[UniRigLoadSkeletonModel] Loading model into GPU memory (delayed load)...")
+                    try:
+                        model_cache_key = model_cache.load_model_into_memory(
+                            model_type="skeleton",
+                            task_config_path=cached_model.get("task_config_path"),
+                            cache_to_gpu=True
+                        )
+                        cached_model["model_cache_key"] = model_cache_key
+                        print(f"[UniRigLoadSkeletonModel] Model loaded into GPU memory")
+                    except Exception as e:
+                        print(f"[UniRigLoadSkeletonModel] Warning: Failed to load into GPU memory: {e}")
+                
             return (cached_model,)
 
         _ensure_unirig_in_path()
@@ -291,6 +308,23 @@ class UniRigLoadSkinningModel:
             # Update cache_to_gpu setting in case it changed
             cached_model["cache_to_gpu"] = cache_to_gpu
             print(f"[UniRigLoadSkinningModel] Using cached model configuration")
+            
+            # If cache_to_gpu is enabled but model is not in GPU memory, load it now
+            if cache_to_gpu and cached_model.get("model_cache_key") is None:
+                model_cache = _get_model_cache()
+                if model_cache:
+                    print(f"[UniRigLoadSkinningModel] Loading model into GPU memory (delayed load)...")
+                    try:
+                        model_cache_key = model_cache.load_model_into_memory(
+                            model_type="skinning",
+                            task_config_path=cached_model.get("task_config_path"),
+                            cache_to_gpu=True
+                        )
+                        cached_model["model_cache_key"] = model_cache_key
+                        print(f"[UniRigLoadSkinningModel] Model loaded into GPU memory")
+                    except Exception as e:
+                        print(f"[UniRigLoadSkinningModel] Warning: Failed to load into GPU memory: {e}")
+                        
             return (cached_model,)
 
         _ensure_unirig_in_path()


### PR DESCRIPTION
### Description: Fix Model Caching and Add VRAM-Saving Fallback

This PR addresses the issue where UniRig would crash if GPU caching was disabled, and improves VRAM management for long-running ComfyUI sessions.

#### Key Changes:
1.  **Dynamic Model Loading Fix**: Fixed a bug in [model_loaders.py](cci:7://file:///home/aero/comfy/ComfyUI/custom_nodes/ComfyUI-UniRig/nodes/model_loaders.py:0:0-0:0) where toggling the `cache_to_gpu` setting would fail to trigger/release GPU memory if the model configuration was already in the cache. 
2.  **VRAM-Saving Fallback (Subprocess Inference)**: Implemented a fallback mechanism for both `UniRig: Extract Skeleton` and `UniRig: Apply Skinning` nodes. When `cache_to_gpu` is disabled, the system now spawns a background process to run inference. This ensures that the ML models (UniRig AR/Skinning) are loaded into VRAM only during execution and are fully released immediately after.
3.  **Platform Independence & Path Handling**:
    *   Switched to `sys.executable` for background worker calls to ensure compatibility across different environments/OS.
    *   Explicitly set the working directory (`cwd`) for subprocesses to resolve `FileNotFoundError` when loading internal configurations.
4.  **Stability Fixes**:
    *   Fixed an `AttributeError` in skeleton parsing where temporary file handles were closed before metadata (bone names) could be read.
    *   Added better error logging and fallback messaging in the ComfyUI console.

#### Verification:
Tested on Linux with `cache_to_gpu=False`. The console now correctly reports:
`[UniRigExtractSkeletonNew] VRAM saving mode: No cached model available. Falling back to subprocess inference...`

This allows users with limited VRAM to use UniRig alongside large models like Flux or SDXL without encountering "Out of Memory" or "No cached model" errors.